### PR TITLE
add support for Jakefile.js

### DIFF
--- a/tasks/bower_postinst.js
+++ b/tasks/bower_postinst.js
@@ -70,7 +70,7 @@ module.exports = function(grunt) {
                     'git submodule'     : grunt.file.exists(compDir + "/.gitmodules"),
                     'npm'               : grunt.file.exists(compDir + "/package.json"),
                     'grunt'             : grunt.file.exists(compDir + "/Gruntfile.js"),
-                    'jake'              : grunt.file.exists(compDir + "/Jakefile"),
+                    'jake'              : grunt.file.exists(compDir + "/Jakefile") || grunt.file.exists(compDir + "/Jakefile.js"),
                     'make'              : grunt.file.exists(compDir + "/Makefile")
                 };
                 


### PR DESCRIPTION
The Jakefile.js format is used in some libraries like leaflet.
