### PR TITLE
Find Gruntfile the same as grunt itself

### DIFF
--- a/tasks/bower_postinst.js
+++ b/tasks/bower_postinst.js
@@ -69,7 +69,7 @@ module.exports = function(grunt) {
                 var detect = {
                     'git submodule'     : grunt.file.exists(compDir + "/.gitmodules"),
                     'npm'               : grunt.file.exists(compDir + "/package.json"),
-                    'grunt'             : grunt.file.exists(compDir + "/Gruntfile.js"),
+                    'grunt'             : grunt.file.findup('Gruntfile.{js,coffee}', {nocase: true}),
                     'jake'              : grunt.file.exists(compDir + "/Jakefile") || grunt.file.exists(compDir + "/Jakefile.js"),
                     'make'              : grunt.file.exists(compDir + "/Makefile")
                 };


### PR DESCRIPTION
When on windows, the original behavior is not really a problem, as file.exists will work on upper and lowercase variant. On Linux however, it fails, while it is valid for grunt itself.
